### PR TITLE
allow Windows Hello Face

### DIFF
--- a/Scripts/apps.ps1
+++ b/Scripts/apps.ps1
@@ -26,7 +26,5 @@ Get-WindowsOptionalFeature -Online | Where-Object { $_.FeatureName -like "Intern
 Write-Host "Disable 'Remote Assistance'"
 Get-WindowsCapability -Online | Where-Object { $_.Name -like "App.Support.QuickAssist*" } | Remove-WindowsCapability -Online
 
-Write-Host "Disable Hello Face"
-Get-WindowsCapability -Online | Where-Object { $_.Name -like "Hello.Face*" } | Remove-WindowsCapability -Online
 
 Write-Host "All done! Please proceed with the new user creation and delete this one afterwards."


### PR DESCRIPTION
Windows Hello Face Unlock doesn't increase or decrease security so their is no need removing it.

Also if webcam isn't available it's not usable anyway. Else it can be used for good biometric but we should harden it: https://www.tenforums.com/tutorials/101265-enable-enhanced-anti-spoofing-windows-hello-face-authentification.html